### PR TITLE
fix c++11 compile error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ project(renum CXX)
 
 ##############################################################################
 
+# C++11 を指定
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)  # C++11 を必須にする
+
 # renum.exe
 add_executable(renum renum.cpp)
 target_compile_definitions(renum PRIVATE -DRENUM_EXE)


### PR DESCRIPTION
ラムダ式でエラーとなるため、C++11 を CMakeLists.txt に指定を加えました。ご確認ください。
/Users/gucchiy/temp/renum/renum.cpp:307:43: error: expected expression
  307 |     std::sort(lines.begin(), lines.end(), [](const std::string& line0, const std::string& line1){